### PR TITLE
Fix initialize_hand_containers typo

### DIFF
--- a/Godot Project/Scripts/Board/in_hand_manager.gd
+++ b/Godot Project/Scripts/Board/in_hand_manager.gd
@@ -20,11 +20,11 @@ func _ready() -> void:
 			sente_in_hand[piece.fen_char] = 0
 			gote_in_hand[piece.fen_char.to_lower()] = 0
 	if game_variant.in_hand_pieces:
-		initalize_hand_containers()
+               initialize_hand_containers()
 		populate_hand_containers()
 		update_hand()
 
-func initalize_hand_containers() -> void:
+func initialize_hand_containers() -> void:
 	sente_container = in_hand_container_scene.instantiate() as InHandContainer
 	gote_container = in_hand_container_scene.instantiate() as InHandContainer
 	sente_container.player = Player.Sente


### PR DESCRIPTION
## Summary
- fix typo in `in_hand_manager.gd`

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f551f395c8329becd113cbb2d08af