### PR TITLE
Implement drag controls

### DIFF
--- a/Godot Project/Scenes/GameBoardScenes/game_piece.tscn
+++ b/Godot Project/Scenes/GameBoardScenes/game_piece.tscn
@@ -3,10 +3,13 @@
 [ext_resource type="Script" uid="uid://2j5dr4koe2kf" path="res://Scripts/Board/game_piece.gd" id="1_sdr3s"]
 [ext_resource type="Script" uid="uid://ceb2dyc1a6ehc" path="res://Scripts/Board/selection_highlight.gd" id="2_mha5q"]
 
-[node name="BaseGamePiece" type="Sprite2D" groups=["game_piece"]]
+[node name="BaseGamePiece" type="Node2D" groups=["game_piece"]]
 z_index = 1
 script = ExtResource("1_sdr3s")
 
+[node name="PieceSprite" type="Sprite2D" parent="."]
+
 [node name="SelectionHighlight" type="Node2D" parent="."]
+visible = false
 z_index = -1
 script = ExtResource("2_mha5q")

--- a/Godot Project/Scenes/GameBoardScenes/in_hand_piece.tscn
+++ b/Godot Project/Scenes/GameBoardScenes/in_hand_piece.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" uid="uid://dokgvc17jfjdf" path="res://Scripts/Board/in_hand_piece.gd" id="1_k53g3"]
 [ext_resource type="Script" uid="uid://ceb2dyc1a6ehc" path="res://Scripts/Board/selection_highlight.gd" id="2_3b4af"]
 
-[node name="InHandPiece" type="Sprite2D"]
+[node name="InHandPiece" type="Node2D"]
 script = ExtResource("1_k53g3")
 
 [node name="SelectionHighlight" type="Node2D" parent="."]

--- a/Godot Project/Scripts/Board/game_manager.gd
+++ b/Godot Project/Scripts/Board/game_manager.gd
@@ -477,7 +477,7 @@ func get_board_square_at_position(global_pos: Vector2) -> Vector2i:
 	var file = board.board_size.x - int(floor(local.x / square_size))
 	var rank = int(floor(local.y / square_size)) + 1
 	if file < 1 or file > board.board_size.x or rank < 1 or rank > board.board_size.y:
-	        return Vector2i(-1, -1)
+		return Vector2i(-1, -1)
 	return Vector2i(file, rank)
 
 func is_inside_board(move: Vector2i) -> bool:

--- a/Godot Project/Scripts/Board/game_manager.gd
+++ b/Godot Project/Scripts/Board/game_manager.gd
@@ -472,6 +472,14 @@ func find_square_center(file: int,rank: int) -> Vector2:
 	var center_y = rank * square_size - square_size / 2
 	return Vector2(center_x, center_y)
 
+func get_board_square_at_position(global_pos: Vector2) -> Vector2i:
+	var local = board.to_local(global_pos)
+	var file = board.board_size.x - int(floor(local.x / square_size))
+	var rank = int(floor(local.y / square_size)) + 1
+	if file < 1 or file > board.board_size.x or rank < 1 or rank > board.board_size.y:
+	        return Vector2i(-1, -1)
+	return Vector2i(file, rank)
+
 func is_inside_board(move: Vector2i) -> bool:
 	return(move.x > 0 and move.x <= board.board_size.x and move.y > 0 and move.y <= board.board_size.y)
 

--- a/Godot Project/Scripts/Board/game_piece.gd
+++ b/Godot Project/Scripts/Board/game_piece.gd
@@ -43,54 +43,54 @@ func _ready() -> void:
 
 func _input(event) -> void:
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and piece_owner == game_manager.player_turn and game_manager.is_promoting == false:
-	        if event.is_pressed() and get_rect().has_point(to_local(event.position)):
-	                if !selected:
-	                        if game_manager.selected_piece != null:
-	                                game_manager.selected_piece.destroy_all_highlights()
-	                                game_manager.selected_piece.selected = false
-	                        selected = true
-	                        game_manager.selected_piece = self
-	                        valid_moves = generate_moves()
-	                        for move in valid_moves:
-	                                var highlight: SquareHighlight = square_highlight.instantiate() as SquareHighlight
-	                                highlight.current_position = move
-	                                var board_position: Vector2 = (current_position - highlight.current_position) * highlight.texture.get_width()
-	                                if piece_owner == Player.Sente:
-	                                        board_position.y *= -1
-	                                if piece_owner == Player.Gote:
-	                                        board_position.x *= -1
-	                                highlight.position = board_position
-	                                highlight.connect("move_piece", Callable(self, "_on_move_piece"))
-	                                add_child(highlight)
-	                dragging = true
-	                drag_start_square = current_position
-	                drag_sprite = Sprite2D.new()
-	                drag_sprite.texture = texture
-	                drag_sprite.scale = scale
-	                drag_sprite.rotation = rotation
-	                drag_sprite.z_index = z_index + 100
-	                game_manager.board.add_child(drag_sprite)
-	                drag_sprite.position = game_manager.board.to_local(event.position)
-	                modulate.a = 0.5
-	                queue_redraw()
-	        elif !event.is_pressed() and dragging:
-	                dragging = false
-	                modulate.a = 1.0
-	                if drag_sprite:
-	                        drag_sprite.queue_free()
-	                        drag_sprite = null
-	                var drop_square = game_manager.get_board_square_at_position(event.position)
-	                if drop_square == drag_start_square:
-	                        pass
-	                elif drop_square in valid_moves:
-	                        _on_move_piece(drop_square)
-	                else:
-	                        destroy_all_highlights()
-	                        selected = false
-	                        game_manager.selected_piece = null
-	                queue_redraw()
+			if event.is_pressed() and get_rect().has_point(to_local(event.position)):
+					if !selected:
+							if game_manager.selected_piece != null:
+									game_manager.selected_piece.destroy_all_highlights()
+									game_manager.selected_piece.selected = false
+							selected = true
+							game_manager.selected_piece = self
+							valid_moves = generate_moves()
+							for move in valid_moves:
+									var highlight: SquareHighlight = square_highlight.instantiate() as SquareHighlight
+									highlight.current_position = move
+									var board_position: Vector2 = (current_position - highlight.current_position) * highlight.texture.get_width()
+									if piece_owner == Player.Sente:
+											board_position.y *= -1
+									if piece_owner == Player.Gote:
+											board_position.x *= -1
+									highlight.position = board_position
+									highlight.connect("move_piece", Callable(self, "_on_move_piece"))
+									add_child(highlight)
+					dragging = true
+					drag_start_square = current_position
+					drag_sprite = Sprite2D.new()
+					drag_sprite.texture = texture
+					drag_sprite.scale = scale
+					drag_sprite.rotation = rotation
+					drag_sprite.z_index = z_index + 100
+					game_manager.board.add_child(drag_sprite)
+					drag_sprite.position = game_manager.board.to_local(event.position)
+					modulate.a = 0.5
+					queue_redraw()
+			elif !event.is_pressed() and dragging:
+					dragging = false
+					modulate.a = 1.0
+					if drag_sprite:
+							drag_sprite.queue_free()
+							drag_sprite = null
+					var drop_square = game_manager.get_board_square_at_position(event.position)
+					if drop_square == drag_start_square:
+							pass
+					elif drop_square in valid_moves:
+							_on_move_piece(drop_square)
+					else:
+							destroy_all_highlights()
+							selected = false
+							game_manager.selected_piece = null
+					queue_redraw()
 	elif event is InputEventMouseMotion and dragging:
-	        drag_sprite.position = game_manager.board.to_local(event.position)
+			drag_sprite.position = game_manager.board.to_local(event.position)
 
 func initialize_values() -> void:
 	if piece_resource:

--- a/Godot Project/Scripts/Board/game_piece.gd
+++ b/Godot Project/Scripts/Board/game_piece.gd
@@ -19,6 +19,8 @@ var is_promoted: bool
 var can_promote: bool
 var selected: bool = false
 var dragging: bool = false
+var drag_sprite: Sprite2D
+var drag_start_square: Vector2i
 var piece_scale: float = 1
 var valid_moves: Array[Vector2i]
 var constrained_moves: Array[Vector2i] = []
@@ -40,30 +42,55 @@ func _ready() -> void:
 		rotation_degrees += 180
 
 func _input(event) -> void:
-	if event is InputEventMouseButton and event.is_pressed() and (piece_owner == game_manager.player_turn) and event.button_index == MOUSE_BUTTON_LEFT and game_manager.is_promoting == false:
-		if get_rect().has_point(to_local(event.position)):
-			selected = !selected
-			if !selected:
-				destroy_all_highlights()
-				game_manager.selected_piece = null
-			else:
-				if game_manager.selected_piece != null:
-					game_manager.selected_piece.destroy_all_highlights()
-					game_manager.selected_piece.selected = false
-				game_manager.selected_piece = self
-				valid_moves = generate_moves()
-				for move in valid_moves:
-					var highlight: SquareHighlight = square_highlight.instantiate() as SquareHighlight
-					highlight.current_position = move
-					var board_position: Vector2 = (current_position - highlight.current_position) * (highlight.texture.get_width())
-					if piece_owner == Player.Sente:
-						board_position.y *= -1
-					if piece_owner == Player.Gote:
-						board_position.x *= -1
-					highlight.position = board_position
-					highlight.connect("move_piece", Callable(self, "_on_move_piece"))
-					add_child(highlight)
-		queue_redraw()
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and piece_owner == game_manager.player_turn and game_manager.is_promoting == false:
+	        if event.is_pressed() and get_rect().has_point(to_local(event.position)):
+	                if !selected:
+	                        if game_manager.selected_piece != null:
+	                                game_manager.selected_piece.destroy_all_highlights()
+	                                game_manager.selected_piece.selected = false
+	                        selected = true
+	                        game_manager.selected_piece = self
+	                        valid_moves = generate_moves()
+	                        for move in valid_moves:
+	                                var highlight: SquareHighlight = square_highlight.instantiate() as SquareHighlight
+	                                highlight.current_position = move
+	                                var board_position: Vector2 = (current_position - highlight.current_position) * highlight.texture.get_width()
+	                                if piece_owner == Player.Sente:
+	                                        board_position.y *= -1
+	                                if piece_owner == Player.Gote:
+	                                        board_position.x *= -1
+	                                highlight.position = board_position
+	                                highlight.connect("move_piece", Callable(self, "_on_move_piece"))
+	                                add_child(highlight)
+	                dragging = true
+	                drag_start_square = current_position
+	                drag_sprite = Sprite2D.new()
+	                drag_sprite.texture = texture
+	                drag_sprite.scale = scale
+	                drag_sprite.rotation = rotation
+	                drag_sprite.z_index = z_index + 100
+	                game_manager.board.add_child(drag_sprite)
+	                drag_sprite.position = game_manager.board.to_local(event.position)
+	                modulate.a = 0.5
+	                queue_redraw()
+	        elif !event.is_pressed() and dragging:
+	                dragging = false
+	                modulate.a = 1.0
+	                if drag_sprite:
+	                        drag_sprite.queue_free()
+	                        drag_sprite = null
+	                var drop_square = game_manager.get_board_square_at_position(event.position)
+	                if drop_square == drag_start_square:
+	                        pass
+	                elif drop_square in valid_moves:
+	                        _on_move_piece(drop_square)
+	                else:
+	                        destroy_all_highlights()
+	                        selected = false
+	                        game_manager.selected_piece = null
+	                queue_redraw()
+	elif event is InputEventMouseMotion and dragging:
+	        drag_sprite.position = game_manager.board.to_local(event.position)
 
 func initialize_values() -> void:
 	if piece_resource:

--- a/Godot Project/Scripts/Board/in_hand_piece.gd
+++ b/Godot Project/Scripts/Board/in_hand_piece.gd
@@ -21,17 +21,17 @@ var square_size: float
 func _ready() -> void:
 	if piece_resource:
 		if piece_resource.icon.size() > 0:
-			texture = piece_resource.icon[0]
-	scale *= square_size / texture.get_size().x
-	rect_size = Vector2(texture.get_width(),texture.get_height())
+			piece_sprite.texture = piece_resource.icon[0]
+	scale *= square_size / piece_sprite.texture.get_size().x
+	rect_size = Vector2(piece_sprite.texture.get_width(),piece_sprite.texture.get_height())
 
 func _input(event) -> void:
 	if event is InputEventMouseButton and event.is_pressed() and event.button_index == MOUSE_BUTTON_LEFT:
 		var local_mouse_position = to_local(event.position)
-		if get_rect().has_point(local_mouse_position):
+		if piece_sprite.get_rect().has_point(local_mouse_position):
 			var piece_count = game_manager.in_hand_manager.get_piece_count_in_hand(player, piece_resource.fen_char_piece_to_add_on_capture if player == Player.Sente else piece_resource.fen_char_piece_to_add_on_capture.to_lower())
 			if piece_owner == game_manager.player_turn and piece_count > 0 and not game_manager.is_promoting:
-				selected = !selected
+				set_selected(!selected)
 				if !selected:
 					valid_moves = []
 					destroy_all_highlights()
@@ -39,7 +39,7 @@ func _input(event) -> void:
 				else:
 					if game_manager.selected_piece != null:
 						game_manager.selected_piece.destroy_all_highlights()
-						game_manager.selected_piece.selected = false
+						game_manager.selected_piece.set_selected(false)
 						valid_moves = []
 					game_manager.selected_piece = self
 					get_valid_moves()
@@ -175,7 +175,7 @@ func would_cause_checkmate(drop_position: Vector2i) -> bool:
 func update_alpha(count: int) -> void:
 	self.modulate.a = 1.0 if count > 0 else 0.3
 	count_label.text = str(count)
-	count_label.position = Vector2(texture.get_width() / 4.0, texture.get_height() / 4.0)
+	count_label.position = Vector2(piece_sprite.texture.get_width() / 4.0, piece_sprite.texture.get_height() / 4.0)
 	count_label.z_index = self.z_index + 1
 
 func destroy_all_highlights() -> void:
@@ -200,4 +200,4 @@ func _draw() -> void:
 		$SelectionHighlight.visible = true
 	else:
 		$SelectionHighlight.visible = false
-	draw_texture(texture,Vector2(float(-texture.get_width())/2,float(-texture.get_height())/2),modulate)
+	draw_texture(piece_sprite.texture,Vector2(float(-piece_sprite.texture.get_width())/2,float(-piece_sprite.texture.get_height())/2),modulate)


### PR DESCRIPTION
## Summary
- support drag controls for game pieces
- help convert mouse drops into board squares

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68649d608f7c832990c5fc8c884fe8e4