### PR TITLE
Refactor piece drop logic to use highlights

### DIFF
--- a/Godot Project/Scripts/Board/game_piece.gd
+++ b/Godot Project/Scripts/Board/game_piece.gd
@@ -83,7 +83,13 @@ func _input(event) -> void:
 		elif not event.is_pressed():
 			if dragging:
 				end_drag()
-				var drop_square = game_manager.get_board_square_at_position(event.position)
+				var drop_square := Vector2i(-1, -1)
+				for child in get_children():
+					if child is SquareHighlight:
+						var local_mouse = child.to_local(event.position)
+						if child.get_rect().has_point(local_mouse):
+							drop_square = child.current_position
+							break
 				if drop_square in valid_moves and drop_square != drag_start_square:
 					_on_move_piece(drop_square)
 				else:

--- a/Godot Project/Scripts/Board/in_hand_piece.gd
+++ b/Godot Project/Scripts/Board/in_hand_piece.gd
@@ -30,7 +30,13 @@ func _unhandled_input(event: InputEvent) -> void:
 
 		elif not event.is_pressed() and dragging:
 			end_drag()
-			var drop_square = game_manager.get_board_square_at_position(event.position)
+			var drop_square := Vector2i(-1, -1)
+			for child in get_children():
+				if child is SquareHighlight:
+					var local_mouse = child.to_local(event.position)
+					if child.get_rect().has_point(local_mouse):
+						drop_square = child.current_position
+						break
 			if drop_square in valid_moves:
 				_on_drop_piece(drop_square)
 			else:


### PR DESCRIPTION
## Summary
- detect valid drop squares by checking hovered highlights
- remove usage of `get_board_square_at_position` when dropping

## Testing
- `echo "no tests"`

------
https://chatgpt.com/codex/tasks/task_e_6868574d2b788329920ad7d39549bbef