### PR TITLE
Fix leftover drag sprite after highlight capture

### DIFF
--- a/Godot Project/Scripts/Board/game_piece.gd
+++ b/Godot Project/Scripts/Board/game_piece.gd
@@ -348,6 +348,8 @@ func set_selected(value: bool) -> void:
 	selection_highlight.visible = selected
 
 func _on_move_piece(move_position: Vector2i) -> void:
+	if dragging:
+		end_drag()
 	move_count += 1
 	var piece_info: PieceInfo = null
 	var coming_from_square:= current_position


### PR DESCRIPTION
## Summary
- ensure any active drag sprite is cleaned up when moving pieces

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686870cf5d4c832981da036d9113e0e3