### PR TITLE
Update in-hand container positioning

### DIFF
--- a/Godot Project/Scripts/Board/in_hand_manager.gd
+++ b/Godot Project/Scripts/Board/in_hand_manager.gd
@@ -11,6 +11,7 @@ var sente_in_hand: Dictionary = {}
 var gote_in_hand: Dictionary = {}
 var sente_container: InHandContainer
 var gote_container: InHandContainer
+@export var container_margin: float = 20.0
 @onready var in_hand_container_scene = preload("res://Scenes/GameBoardScenes/in_hand_piece_container.tscn")
 @onready var in_hand_piece_scene = preload("res://Scenes/GameBoardScenes/in_hand_piece.tscn")
 
@@ -30,10 +31,9 @@ func initialize_hand_containers() -> void:
 	gote_container = in_hand_container_scene.instantiate() as InHandContainer
 	sente_container.player = Player.Sente
 	gote_container.player = Player.Gote
+	gote_container.rotation_degrees = 180
 	add_child(sente_container)
 	add_child(gote_container)
-	sente_container.position = Vector2(100,200)
-	gote_container.position = Vector2(200,200)
 	#sente_container.position = Vector2(game_manager.board.position.x + game_manager.board.texture.get_width(), game_manager.board.position.y)
 	#gote_container.position = Vector2(game_manager.board.position.x - game_manager.board.square_size, game_manager.board.position.y)
 
@@ -60,6 +60,7 @@ func populate_hand_containers() -> void:
 		gote_container.add_child(in_hand_piece)
 	sente_container.arrange_children()
 	gote_container.arrange_children()
+	position_hand_containers()
 
 func add_piece_to_hand(player: Player, piece: PieceBase) -> void:
 	if player == Player.Sente:
@@ -114,3 +115,26 @@ func update_piece_scales(new_square_size: float) -> void:
 					if texture_width > 0:
 						var scale_factor = new_square_size / texture_width
 						child.scale = Vector2.ONE * scale_factor
+func position_hand_containers() -> void:
+	var board := game_manager.board
+	var font := ThemeDB.fallback_font
+	var label_width := font.get_string_size("1", HORIZONTAL_ALIGNMENT_CENTER, -1, board.font_size).x
+	var board_bottom := board.position.y + board.texture.get_height() * board.scale.y
+	var board_top := board.position.y
+	var board_left := board.position.x
+	var board_right := board.position.x + board.texture.get_width() * board.scale.x
+	var sente_size := _get_container_size(sente_container)
+	var gote_size := _get_container_size(gote_container)
+	sente_container.position = Vector2(board_right + label_width + container_margin, board_bottom - sente_size.y)
+	gote_container.position = Vector2(board_left - label_width - container_margin, board_top + gote_size.y)
+
+func _get_container_size(container: InHandContainer) -> Vector2:
+	var max_x := 0.0
+	var max_y := 0.0
+	for child in container.get_children():
+		if child is InHandPiece:
+			var sprite := child.piece_sprite
+			var size := sprite.texture.get_size() * child.scale
+			max_x = max(max_x, child.position.x + size.x)
+			max_y = max(max_y, child.position.y + size.y)
+	return Vector2(max_x, max_y)


### PR DESCRIPTION
## Summary
- make margin configurable for in-hand containers
- position in-hand containers relative to board edges
- rotate the gote container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869603253a88329829e66755a60a0a8