### PR TITLE
Update in-hand container layout

### DIFF
--- a/Godot Project/Scripts/Board/in_hand_manager.gd
+++ b/Godot Project/Scripts/Board/in_hand_manager.gd
@@ -125,16 +125,28 @@ func position_hand_containers() -> void:
 	var board_right := board.position.x + board.texture.get_width() * board.scale.x
 	var sente_size := _get_container_size(sente_container)
 	var gote_size := _get_container_size(gote_container)
-	sente_container.position = Vector2(board_right + label_width + container_margin, board_bottom - sente_size.y)
-	gote_container.position = Vector2(board_left - label_width - container_margin, board_top + gote_size.y)
+	sente_container.position = Vector2(board_right + label_width + container_margin, board_bottom)
+	gote_container.position = Vector2(board_left - label_width - container_margin, board_top)
 
 func _get_container_size(container: InHandContainer) -> Vector2:
+	var min_x := 0.0
 	var max_x := 0.0
+	var min_y := 0.0
 	var max_y := 0.0
+	var first := true
 	for child in container.get_children():
-		if child is InHandPiece:
-			var sprite: Sprite2D = child.piece_sprite
-			var size: Vector2 = sprite.texture.get_size() * child.scale
-			max_x = max(max_x, child.position.x + size.x)
-			max_y = max(max_y, child.position.y + size.y)
-	return Vector2(max_x, max_y)
+	       if child is InHandPiece:
+	               var sprite: Sprite2D = child.piece_sprite
+	               var size: Vector2 = sprite.texture.get_size() * child.scale
+	               if first:
+	                       min_x = child.position.x
+	                       max_x = child.position.x + size.x
+	                       min_y = child.position.y
+	                       max_y = child.position.y + size.y
+	                       first = false
+	               else:
+	                       min_x = min(min_x, child.position.x)
+	                       max_x = max(max_x, child.position.x + size.x)
+	                       min_y = min(min_y, child.position.y)
+	                       max_y = max(max_y, child.position.y + size.y)
+	return Vector2(max_x - min_x, max_y - min_y)

--- a/Godot Project/Scripts/Board/in_hand_manager.gd
+++ b/Godot Project/Scripts/Board/in_hand_manager.gd
@@ -135,18 +135,18 @@ func _get_container_size(container: InHandContainer) -> Vector2:
 	var max_y := 0.0
 	var first := true
 	for child in container.get_children():
-	       if child is InHandPiece:
-	               var sprite: Sprite2D = child.piece_sprite
-	               var size: Vector2 = sprite.texture.get_size() * child.scale
-	               if first:
-	                       min_x = child.position.x
-	                       max_x = child.position.x + size.x
-	                       min_y = child.position.y
-	                       max_y = child.position.y + size.y
-	                       first = false
-	               else:
-	                       min_x = min(min_x, child.position.x)
-	                       max_x = max(max_x, child.position.x + size.x)
-	                       min_y = min(min_y, child.position.y)
-	                       max_y = max(max_y, child.position.y + size.y)
+		if child is InHandPiece:
+			var sprite: Sprite2D = child.piece_sprite
+			var size: Vector2 = sprite.texture.get_size() * child.scale
+			if first:
+				min_x = child.position.x
+				max_x = child.position.x + size.x
+				min_y = child.position.y
+				max_y = child.position.y + size.y
+				first = false
+			else:
+				min_x = min(min_x, child.position.x)
+				max_x = max(max_x, child.position.x + size.x)
+				min_y = min(min_y, child.position.y)
+				max_y = max(max_y, child.position.y + size.y)
 	return Vector2(max_x - min_x, max_y - min_y)

--- a/Godot Project/Scripts/Board/in_hand_piece_container.gd
+++ b/Godot Project/Scripts/Board/in_hand_piece_container.gd
@@ -21,7 +21,8 @@ func arrange_children() -> void:
 	var max_x = 0.0
 	var max_y = 0.0
 	var children := get_children()
-	for child in children.reversed():
+	children.reverse()
+	for child in children:
 		if child is InHandPiece:
 			child.position = Vector2(x_offset, y_offset)
 			min_x = min(min_x, child.position.x)

--- a/Godot Project/Scripts/Board/in_hand_piece_container.gd
+++ b/Godot Project/Scripts/Board/in_hand_piece_container.gd
@@ -16,15 +16,22 @@ func arrange_children() -> void:
 	var y_offset = 0.0
 	var row_height = square_size + v_separation
 	var column_width = square_size + h_separation
-	var num_children = get_child_count()
 	var current_column = 0
-	for i in range(num_children):
-		var child = get_child(i)
+	var min_x = 0.0
+	var max_x = 0.0
+	var max_y = 0.0
+	for child in get_children():
 		if child is InHandPiece:
 			child.position = Vector2(x_offset, y_offset)
+			min_x = min(min_x, child.position.x)
+			max_x = max(max_x, child.position.x + column_width - h_separation)
+			max_y = max(max_y, child.position.y)
 			x_offset += column_width
 			current_column += 1
-			if current_column >= columns or y_offset + row_height > max_height:
-				x_offset = 0
-				y_offset += row_height
+			if current_column >= columns or abs(y_offset) + row_height > max_height:
+				x_offset = 0.0
+				y_offset -= row_height
 				current_column = 0
+	for child in get_children():
+		if child is InHandPiece:
+			child.position -= Vector2((max_x + min_x) / 2.0, max_y)

--- a/Godot Project/Scripts/Board/in_hand_piece_container.gd
+++ b/Godot Project/Scripts/Board/in_hand_piece_container.gd
@@ -20,7 +20,8 @@ func arrange_children() -> void:
 	var min_x = 0.0
 	var max_x = 0.0
 	var max_y = 0.0
-	for child in get_children():
+	var children := get_children()
+	for child in children.reversed():
 		if child is InHandPiece:
 			child.position = Vector2(x_offset, y_offset)
 			min_x = min(min_x, child.position.x)
@@ -32,6 +33,6 @@ func arrange_children() -> void:
 				x_offset = 0.0
 				y_offset -= row_height
 				current_column = 0
-	for child in get_children():
-		if child is InHandPiece:
-			child.position -= Vector2((max_x + min_x) / 2.0, max_y)
+	for child in children:
+			if child is InHandPiece:
+				child.position -= Vector2((max_x + min_x) / 2.0, max_y)


### PR DESCRIPTION
## Summary
- populate in-hand pieces upward from the container origin
- center pieces horizontally by shifting them after layout
- position containers using their new bottom‐center origin
- compute container size using bounding boxes

## Testing
- `grep -n '^[ ]' -n 'Godot Project/Scripts/Board/in_hand_manager.gd'`

------
https://chatgpt.com/codex/tasks/task_e_686970f4226883298895f39010529715