### PR TITLE
Fix promotion bug when scrubbing PGN

### DIFF
--- a/Godot Project/Scripts/Board/game_manager.gd
+++ b/Godot Project/Scripts/Board/game_manager.gd
@@ -469,6 +469,16 @@ func record_move() -> void:
 	if notation_manager and fen_manager:
 		notation_manager.add_sfen(fen_manager.get_fen_notation())
 
+func cancel_promotion() -> void:
+	if not is_promoting:
+		return
+	is_promoting = false
+	if selected_piece:
+		if selected_piece.get_child_count() > 0:
+			selected_piece.get_child(selected_piece.get_child_count() - 1).queue_free()
+		selected_piece.pending_handle_action = false
+		selected_piece = null
+
 func set_variant(variant: GameVariant) -> void:
 	game_variant = variant
 

--- a/Godot Project/Scripts/Board/portable_game_notation.gd
+++ b/Godot Project/Scripts/Board/portable_game_notation.gd
@@ -24,6 +24,7 @@ func _on_move_slider_value_changed(value: float) -> void:
 	_set_board_to_index(int(value))
 
 func _set_board_to_index(index: int) -> void:
+	game_manager.cancel_promotion()
 	if index < 0 or index >= history.size():
 		return
 	var sfen = history[index]


### PR DESCRIPTION
## Summary
- prevent partial promotions from being recorded by adding `cancel_promotion` to the game manager
- ensure the promotion is cancelled when the PGN slider scrubs the game state

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686b14da9ff08329867b2ab89492d29c