### PR TITLE
Revamp PGN interface

### DIFF
--- a/Godot Project/Scenes/GameBoardScenes/portable_game_notation.tscn
+++ b/Godot Project/Scenes/GameBoardScenes/portable_game_notation.tscn
@@ -1,42 +1,66 @@
-[gd_scene load_steps=5 format=3]
+[gd_scene load_steps=2 format=3 uid="uid://boeueyw1npvg3"]
 
-[ext_resource type="Script" path="res://Scripts/Board/portable_game_notation.gd" id="1"]
+[ext_resource type="Script" uid="uid://b4l6tkm12mj8w" path="res://Scripts/Board/portable_game_notation.gd" id="1"]
 
-[node name="PortableGameNotation" type="Node2D"]
+[node name="PortableGameNotation" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
 script = ExtResource("1")
 
 [node name="Panel" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 11
 anchor_left = 1.0
 anchor_right = 1.0
-anchor_top = 0.0
 anchor_bottom = 1.0
 offset_left = -200.0
+grow_horizontal = 0
+grow_vertical = 2
 
 [node name="ScrollContainer" type="ScrollContainer" parent="Panel"]
+layout_mode = 1
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_bottom = 40.0
+offset_right = -200.0
+offset_bottom = -720.0
+grow_horizontal = 2
+grow_vertical = 2
 vertical_scroll_mode = 2
 
 [node name="MovesVBox" type="VBoxContainer" parent="Panel/ScrollContainer"]
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="ButtonsHBox" type="HBoxContainer" parent="Panel"]
-anchor_left = 0.0
+layout_mode = 1
+anchors_preset = 12
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_top = -40.0
+grow_horizontal = 2
+grow_vertical = 0
 
 [node name="FirstButton" type="Button" parent="Panel/ButtonsHBox"]
+layout_mode = 2
 text = "<<"
 
 [node name="BackButton" type="Button" parent="Panel/ButtonsHBox"]
+layout_mode = 2
 text = "<"
 
 [node name="ForwardButton" type="Button" parent="Panel/ButtonsHBox"]
+layout_mode = 2
 text = ">"
 
 [node name="LastButton" type="Button" parent="Panel/ButtonsHBox"]
+layout_mode = 2
 text = ">>"

--- a/Godot Project/Scenes/GameBoardScenes/portable_game_notation.tscn
+++ b/Godot Project/Scenes/GameBoardScenes/portable_game_notation.tscn
@@ -1,21 +1,42 @@
-[gd_scene load_steps=2 format=3]
+[gd_scene load_steps=5 format=3]
 
 [ext_resource type="Script" path="res://Scripts/Board/portable_game_notation.gd" id="1"]
 
 [node name="PortableGameNotation" type="Node2D"]
 script = ExtResource("1")
-position = Vector2(600, 0)
 
-[node name="MoveSlider" type="HSlider" parent="."]
-min_value = 0.0
-max_value = 0.0
-step = 1.0
-value = 0.0
-offset_right = 300.0
+[node name="Panel" type="Panel" parent="."]
+anchor_left = 1.0
+anchor_right = 1.0
+anchor_top = 0.0
+anchor_bottom = 1.0
+offset_left = -200.0
 
-[node name="MoveLabel" type="Label" parent="."]
-offset_left = 0.0
-offset_top = 20.0
-text = "Move 1"
+[node name="ScrollContainer" type="ScrollContainer" parent="Panel"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_bottom = 40.0
+vertical_scroll_mode = 2
 
-[connection signal="value_changed" from="MoveSlider" to="." method="_on_move_slider_value_changed"]
+[node name="MovesVBox" type="VBoxContainer" parent="Panel/ScrollContainer"]
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="ButtonsHBox" type="HBoxContainer" parent="Panel"]
+anchor_left = 0.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_top = -40.0
+
+[node name="FirstButton" type="Button" parent="Panel/ButtonsHBox"]
+text = "<<"
+
+[node name="BackButton" type="Button" parent="Panel/ButtonsHBox"]
+text = "<"
+
+[node name="ForwardButton" type="Button" parent="Panel/ButtonsHBox"]
+text = ">"
+
+[node name="LastButton" type="Button" parent="Panel/ButtonsHBox"]
+text = ">>"

--- a/Godot Project/Scripts/Board/portable_game_notation.gd
+++ b/Godot Project/Scripts/Board/portable_game_notation.gd
@@ -1,37 +1,164 @@
 extends Node2D
 class_name PortableGameNotation
 
-@onready var move_slider = $MoveSlider
-@onready var move_label = $MoveLabel
+@onready var move_list: VBoxContainer = $Panel/ScrollContainer/MovesVBox
+@onready var first_button: Button = $Panel/ButtonsHBox/FirstButton
+@onready var back_button: Button = $Panel/ButtonsHBox/BackButton
+@onready var forward_button: Button = $Panel/ButtonsHBox/ForwardButton
+@onready var last_button: Button = $Panel/ButtonsHBox/LastButton
 
 var game_manager: GameManager
 var history: Array[String] = []
+var move_notations: Array[String] = []
+var current_index: int = 0
 
 func _ready() -> void:
-	move_slider.min_value = 0
-	move_slider.max_value = 0
-	move_slider.step = 1
-	move_slider.value = 0
+	first_button.pressed.connect(_on_first_pressed)
+	back_button.pressed.connect(_on_back_pressed)
+	forward_button.pressed.connect(_on_forward_pressed)
+	last_button.pressed.connect(_on_last_pressed)
 
 func add_sfen(sfen: String) -> void:
 	history.append(sfen)
-	move_slider.max_value = history.size() - 1
-	move_slider.value = history.size() - 1
-	_update_label(int(move_slider.value))
+	if history.size() > 1:
+		var notation = _compute_move_notation(history[history.size() - 2], sfen)
+		move_notations.append(notation)
+		_add_move_button(history.size() - 1, notation)
+	_set_board_to_index(history.size() - 1)
 
-func _on_move_slider_value_changed(value: float) -> void:
-	_update_label(int(value))
-	_set_board_to_index(int(value))
+func _on_first_pressed() -> void:
+	_set_board_to_index(0)
+
+func _on_back_pressed() -> void:
+	_set_board_to_index(max(current_index - 1, 0))
+
+func _on_forward_pressed() -> void:
+	_set_board_to_index(min(current_index + 1, history.size() - 1))
+
+func _on_last_pressed() -> void:
+	_set_board_to_index(history.size() - 1)
 
 func _set_board_to_index(index: int) -> void:
 	game_manager.cancel_promotion()
 	if index < 0 or index >= history.size():
 		return
+	current_index = index
 	var sfen = history[index]
 	game_manager.fen_manager.create_board_from_fen(sfen)
 	game_manager.start_phase()
 	game_manager.allow_input = index == history.size() - 1
 
-func _update_label(index: int) -> void:
-	if move_label:
-		move_label.text = "Move " + str(index + 1)
+func _add_move_button(number: int, notation: String) -> void:
+	var row = HBoxContainer.new()
+	var move_button = Button.new()
+	move_button.text = str(number)
+	move_button.pressed.connect(_on_move_button_pressed.bind(number))
+	var label = Label.new()
+	label.text = notation
+	row.add_child(move_button)
+	row.add_child(label)
+	move_list.add_child(row)
+
+func _on_move_button_pressed(index: int) -> void:
+	_set_board_to_index(index)
+
+func _compute_move_notation(prev_sfen: String, new_sfen: String) -> String:
+	var prev_parts = prev_sfen.split(" ")
+	var new_parts = new_sfen.split(" ")
+	var prev_board = _parse_board(prev_parts[0])
+	var new_board = _parse_board(new_parts[0])
+	var prev_hand = _parse_hand(prev_parts.size() > 2 ? prev_parts[2] : "-")
+	var new_hand = _parse_hand(new_parts.size() > 2 ? new_parts[2] : "-")
+	var player = prev_parts[1] == "b" ? GameManager.Player.Sente : GameManager.Player.Gote
+	var drop_piece = ""
+	for piece in prev_hand.keys():
+		var prev_count = prev_hand[piece]
+		var new_count = new_hand.get(piece, 0)
+		if player == GameManager.Player.Sente and piece == piece.to_upper() and new_count < prev_count:
+			drop_piece = piece.to_upper()
+			break
+		elif player == GameManager.Player.Gote and piece == piece.to_lower() and new_count < prev_count:
+			drop_piece = piece.to_upper()
+			break
+	if drop_piece != "":
+		for pos in new_board.keys():
+			if not prev_board.has(pos) and _is_player_piece(new_board[pos], player):
+				return drop_piece + "*" + _coord_to_string(pos)
+	var from_square = null
+	var to_square = null
+	var from_char = ""
+	var to_char = ""
+	for pos in prev_board.keys():
+		var prev_char = prev_board[pos]
+		var curr_char = new_board.get(pos, "")
+		if _is_player_piece(prev_char, player) and prev_char != curr_char:
+			from_square = pos
+			from_char = prev_char
+			break
+	for pos in new_board.keys():
+		var prev_char = prev_board.get(pos, "")
+		var curr_char = new_board[pos]
+		if _is_player_piece(curr_char, player) and curr_char != prev_char:
+			to_square = pos
+			to_char = curr_char
+			break
+	if from_square == null or to_square == null:
+		return ""
+	var capture = prev_board.has(to_square) and prev_board[to_square] != "" and not _is_player_piece(prev_board[to_square], player)
+	var piece_type = _strip_plus(from_char).to_upper()
+	var notation = piece_type + (capture ? "x" : "-") + _coord_to_string(to_square)
+	var could_promote = false
+	var idx = game_manager.fen_manager.get_piece_type_from_symbol(piece_type)
+	if idx != -1:
+		var piece_base: PieceBase = game_manager.game_variant.pieces[idx]
+		could_promote = piece_base.can_promote and not piece_base.is_promoted
+	var promoted = not from_char.begins_with("+") and to_char.begins_with("+")
+	if could_promote:
+		notation += "+" if promoted else "="
+	return notation
+
+func _parse_board(board_str: String) -> Dictionary:
+	var result: Dictionary = {}
+	var ranks = board_str.split("/")
+	for y in range(ranks.size()):
+		var row = ranks[y]
+		var x = 0
+		var i = 0
+		while i < row.length():
+			var c = row[i]
+			if c.is_valid_int():
+				x += int(c)
+			else:
+				var piece_char = c
+				if c == "+" and i + 1 < row.length():
+					i += 1
+					piece_char += row[i]
+				var file = game_manager.board.board_size.x - x
+				var rank = y + 1
+				result[Vector2i(file, rank)] = piece_char
+				x += 1
+			i += 1
+	return result
+
+func _parse_hand(hand_str: String) -> Dictionary:
+	var counts: Dictionary = {}
+	if hand_str == "-" or hand_str == "":
+		return counts
+	var number = ""
+	for c in hand_str:
+		if c.is_valid_int():
+			number += c
+		else:
+			var count = int(number) if number != "" else 1
+			counts[c] = counts.get(c, 0) + count
+			number = ""
+	return counts
+
+func _coord_to_string(pos: Vector2i) -> String:
+	return str(pos.x) + str(pos.y)
+
+func _is_player_piece(char: String, player: GameManager.Player) -> bool:
+	return (player == GameManager.Player.Sente and char == char.to_upper()) or (player == GameManager.Player.Gote and char == char.to_lower())
+
+func _strip_plus(char: String) -> String:
+	return char.substr(1) if char.begins_with("+") else char

--- a/Godot Project/Scripts/Board/portable_game_notation.gd
+++ b/Godot Project/Scripts/Board/portable_game_notation.gd
@@ -1,4 +1,4 @@
-extends Node2D
+extends Control
 class_name PortableGameNotation
 
 @onready var move_list: VBoxContainer = $Panel/ScrollContainer/MovesVBox

--- a/Godot Project/Scripts/Board/portable_game_notation.gd
+++ b/Godot Project/Scripts/Board/portable_game_notation.gd
@@ -67,9 +67,9 @@ func _compute_move_notation(prev_sfen: String, new_sfen: String) -> String:
 	var new_parts = new_sfen.split(" ")
 	var prev_board = _parse_board(prev_parts[0])
 	var new_board = _parse_board(new_parts[0])
-	var prev_hand = _parse_hand(prev_parts.size() > 2 ? prev_parts[2] : "-")
-	var new_hand = _parse_hand(new_parts.size() > 2 ? new_parts[2] : "-")
-	var player = prev_parts[1] == "b" ? GameManager.Player.Sente : GameManager.Player.Gote
+	var prev_hand = _parse_hand(prev_parts[2] if prev_parts.size() > 2 else "-")
+	var new_hand = _parse_hand(new_parts[2] if new_parts.size() > 2 else "-")
+	var player = GameManager.Player.Sente if prev_parts[1] == "b" else GameManager.Player.Gote
 	var drop_piece = ""
 	for piece in prev_hand.keys():
 		var prev_count = prev_hand[piece]
@@ -106,7 +106,7 @@ func _compute_move_notation(prev_sfen: String, new_sfen: String) -> String:
 		return ""
 	var capture = prev_board.has(to_square) and prev_board[to_square] != "" and not _is_player_piece(prev_board[to_square], player)
 	var piece_type = _strip_plus(from_char).to_upper()
-	var notation = piece_type + (capture ? "x" : "-") + _coord_to_string(to_square)
+	var notation = piece_type + ("x" if capture else "-") + _coord_to_string(to_square)
 	var could_promote = false
 	var idx = game_manager.fen_manager.get_piece_type_from_symbol(piece_type)
 	if idx != -1:


### PR DESCRIPTION
## Summary
- redesign portable game notation scene with a panel, scroll list and buttons
- implement new PGN logic to display moves and navigate history

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b1f0788c0832992bcf4d0afab7e08